### PR TITLE
Update dependencies package name for Debian installations so they match what the app expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ brew install mpv ffmpeg
 
 On Linux:
 ```bash
-sudo apt install mpv ffmpeg  # Debian/Ubuntu
+sudo apt install ffmpeg  # Debian/Ubuntu
+sudo apt install python3-mpv
 ```
 
 ## Usage


### PR DESCRIPTION
Currently the docs state to install mpv via apt, yet it doesn't detect the package if installed using apt. 

When mpv is installed via python3-mpv package, radio runs properly.